### PR TITLE
Fix #47 Add eslint-plugin-sort-class-members

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,9 @@ autoformatting your code.
 | **Total: `hardcore` + `hardcore/fp`**                                                                     |   554 | **441** |
 | [eslint-plugin-node](https://github.com/mysticatea/eslint-plugin-node)                                    |    37 |  **35** |
 | **Total: `hardcore` + `hardcore/fp` + `hardcore/node`**                                                   |   591 | **476** |
-| [typescript-eslint](https://github.com/typescript-eslint/typescript-eslint)                               |   107 |  **44** |
-| **Total: `hardcore` + `hardcore/fp` + `hardcore/node` + `hardcore/ts-for-js`**                            |   698 | **501** |
+| [typescript-eslint](https://github.com/typescript-eslint/typescript-eslint)                               |   107 |  **43** |
+| [eslint-plugin-sort-class-members](https://github.com/bryanrsmith/eslint-plugin-sort-class-members)       |     1 |   **1** |
+| **Total: `hardcore` + `hardcore/fp` + `hardcore/node` + `hardcore/ts-for-js`**                            |   699 | **501** |
 
 ¹ eslint-plugin-json actually includes 19 rules, but I consider them as one
 "no-invalid-json" rule.

--- a/package-lock.json
+++ b/package-lock.json
@@ -915,6 +915,11 @@
       "resolved": "https://registry.npmjs.org/eslint-plugin-sonarjs/-/eslint-plugin-sonarjs-0.5.0.tgz",
       "integrity": "sha512-XW5MnzlRjhXpIdbULC/qAdJYHWw3rRLws/DyawdlPU/IdVr9AmRK1r2LaCvabwKOAW2XYYSo3kDX58E4MrB7PQ=="
     },
+    "eslint-plugin-sort-class-members": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-sort-class-members/-/eslint-plugin-sort-class-members-1.8.0.tgz",
+      "integrity": "sha512-2DY2xgmcpHeTYgXrkAV2b7rQI1+6PhuAn/KWwU9ttiUF8V/V7dgu48Eru/67GfAPs+p6H6XDlaT2NjBpH2l+Qg=="
+    },
     "eslint-plugin-unicorn": {
       "version": "22.0.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-unicorn/-/eslint-plugin-unicorn-22.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "eslint-plugin-ramda": "^2.5.1",
     "eslint-plugin-security": "^1.4.0",
     "eslint-plugin-sonarjs": "^0.5.0",
+    "eslint-plugin-sort-class-members": "^1.8.0",
     "eslint-plugin-unicorn": "^22.0.0",
     "prettier": "^2.1.2",
     "typescript": "^4.0.3"

--- a/sort-class-members-test.js
+++ b/sort-class-members-test.js
@@ -13,7 +13,7 @@
 
 "use strict";
 
-class Foo {
+class Example {
   static staticProperty;
 
   static staticArrowFunctionProperty = () => {};

--- a/sort-class-members-test.js
+++ b/sort-class-members-test.js
@@ -18,27 +18,23 @@ class Foo {
 
   static staticArrowFunctionProperty = () => {};
 
-  static staticMethod() {}
-
-  static async staticAsyncMethod() {}
-
   static get staticAccessorPair() {}
 
   static set staticAccessorPair(value) {}
 
-  static get getter() {}
+  static get staticGetter() {}
 
-  static set setter(value) {}
+  static set staticSetter(value) {}
+
+  static staticMethod() {}
+
+  static async staticAsyncMethod() {}
 
   @decorator decoratedProperty = "bar";
 
   property = "bar";
 
   arrowFunctionProperty = () => {};
-
-  static _conventionalStaticPrivateProperty;
-
-  _conventionalPrivateProperty;
 
   constructor() {}
 
@@ -56,9 +52,17 @@ class Foo {
   method() {}
 
   @decorator
-  async asyncDecoratedMethod() {}
+  async decoratedAsyncMethod() {}
 
   async asyncMethod() {}
+
+  static _staticConventionalPrivateProperty;
+
+  static _staticConventionalPrivateMethod() {}
+
+  static async _staticAsyncConventionalPrivateMethod() {}
+
+  _conventionalPrivateProperty;
 
   _conventionalPrivateMethod() {}
 

--- a/sort-class-members.js
+++ b/sort-class-members.js
@@ -1,0 +1,66 @@
+/* eslint-disable
+  fp/no-class,
+  @typescript-eslint/no-empty-function,
+  @typescript-eslint/no-useless-constructor,
+  class-methods-use-this,
+  @typescript-eslint/no-unused-vars,
+  @typescript-eslint/naming-convention,
+  no-underscore-dangle,
+  getter-return,
+  accessor-pairs,
+  no-undef
+*/
+
+"use strict";
+
+class Foo {
+  static staticProperty;
+
+  static staticArrowFunctionProperty = () => {};
+
+  static staticMethod() {}
+
+  static async staticAsyncMethod() {}
+
+  static get staticAccessorPair() {}
+
+  static set staticAccessorPair(value) {}
+
+  static get getter() {}
+
+  static set setter(value) {}
+
+  @decorator decoratedProperty = "bar";
+
+  property = "bar";
+
+  arrowFunctionProperty = () => {};
+
+  static _conventionalStaticPrivateProperty;
+
+  _conventionalPrivateProperty;
+
+  constructor() {}
+
+  get accessorPair() {}
+
+  set accessorPair(value) {}
+
+  get getter() {}
+
+  set setter(value) {}
+
+  @decorator
+  decoratedMethod() {}
+
+  method() {}
+
+  @decorator
+  async asyncDecoratedMethod() {}
+
+  async asyncMethod() {}
+
+  _conventionalPrivateMethod() {}
+
+  async _asyncConventionalPrivateMethod() {}
+}

--- a/ts-for-js.json
+++ b/ts-for-js.json
@@ -142,19 +142,63 @@
     "sort-class-members/sort-class-members": [
       "error",
       {
+        "groups": {
+          "static-arrow-function-properties": {
+            "static": true,
+            "propertyType": "ArrowFunctionExpression"
+          },
+          "static-async-methods": {
+            "static": true,
+            "type": "method",
+            "async": true
+          },
+          "static-accessor-pairs": { "static": true, "accessorPair": true },
+          "static-getters": { "static": true, "kind": "get" },
+          "static-setters": { "static": true, "kind": "set" },
+          "static-conventional-private-properties": {
+            "static": true,
+            "type": "property",
+            "name": "/_.+/"
+          },
+          "static-conventional-private-methods": {
+            "static": true,
+            "type": "method",
+            "name": "/_.+/"
+          },
+          "static-async-conventional-private-methods": {
+            "static": true,
+            "type": "method",
+            "name": "/_.+/",
+            "async": true
+          },
+          "async-conventional-private-methods": {
+            "type": "method",
+            "name": "/_.+/",
+            "async": true
+          }
+        },
         "order": [
           "[static-properties]",
+          "[static-arrow-function-properties]",
+          "[static-accessor-pairs]",
+          "[static-getters]",
+          "[static-setters]",
           "[static-methods]",
+          "[static-async-methods]",
           "[properties]",
           "[arrow-function-properties]",
-          "[conventional-private-properties]",
           "constructor",
           "[accessor-pairs]",
           "[getters]",
           "[setters]",
           "[methods]",
           "[async-methods]",
-          "[conventional-private-methods]"
+          "[static-conventional-private-properties]",
+          "[static-conventional-private-methods]",
+          "[static-async-conventional-private-methods]",
+          "[conventional-private-properties]",
+          "[conventional-private-methods]",
+          "[async-conventional-private-methods]"
         ],
         "accessorPairPositioning": "getThenSet"
       }

--- a/ts-for-js.json
+++ b/ts-for-js.json
@@ -1,7 +1,7 @@
 {
   "parser": "@typescript-eslint/parser",
 
-  "plugins": ["@typescript-eslint"],
+  "plugins": ["@typescript-eslint", "sort-class-members"],
 
   "rules": {
     "default-param-last": "off",
@@ -84,7 +84,6 @@
     "@typescript-eslint/await-thenable": "error",
     "@typescript-eslint/ban-ts-comment": "error",
     "@typescript-eslint/ban-tslint-comment": "error",
-    "@typescript-eslint/member-ordering": "error",
     "@typescript-eslint/no-base-to-string": "error",
     "@typescript-eslint/no-dynamic-delete": "error",
     "@typescript-eslint/no-extraneous-class": "error",
@@ -137,6 +136,27 @@
         "types": ["boolean"],
         "format": ["PascalCase"],
         "prefix": ["is", "should", "has", "can", "did", "will"]
+      }
+    ],
+
+    "sort-class-members/sort-class-members": [
+      "error",
+      {
+        "order": [
+          "[static-properties]",
+          "[static-methods]",
+          "[properties]",
+          "[arrow-function-properties]",
+          "[conventional-private-properties]",
+          "constructor",
+          "[accessor-pairs]",
+          "[getters]",
+          "[setters]",
+          "[methods]",
+          "[async-methods]",
+          "[conventional-private-methods]"
+        ],
+        "accessorPairPositioning": "getThenSet"
       }
     ]
   }


### PR DESCRIPTION
Fix #47 Add [eslint-plugin-sort-class-members](https://github.com/bryanrsmith/eslint-plugin-sort-class-members).

Groups:

1. public static
2. public instance
3. "private" (with leading `_`) static 
4. "private" (with leading `_`) instance

Order within groups:

1. properties
2. arrow functions
3. constructor
4. accessor pairs
5. lonely getters
6. lonely setters
7. methods
8. async methods
