### PR TITLE
Disable certain rules for Vue and Nuxt

### DIFF
--- a/esm/test-jsx.jsx
+++ b/esm/test-jsx.jsx
@@ -1,7 +1,6 @@
 /*
   eslint-disable-next-line
   import/no-unused-modules,
-  import/no-anonymous-default-export,
   vue/require-direct-export
 */
 export default "test";

--- a/esm/test-ts.ts
+++ b/esm/test-ts.ts
@@ -1,6 +1,5 @@
 /*
   eslint-disable-next-line
-  import/no-unused-modules,
-  import/no-anonymous-default-export
+  import/no-unused-modules
 */
 export default "test";

--- a/esm/test-tsx.tsx
+++ b/esm/test-tsx.tsx
@@ -1,6 +1,5 @@
 /*
   eslint-disable-next-line
-  import/no-unused-modules,
-  import/no-anonymous-default-export
+  import/no-unused-modules
 */
 export default "test";

--- a/vue.json
+++ b/vue.json
@@ -102,7 +102,10 @@
             "message": "The comma operator is confusing and a common mistake. Don’t use it!"
           }
         ],
-        "vue/no-required-prop-with-default": ["error", { "autofix": true }]
+        "vue/no-required-prop-with-default": ["error", { "autofix": true }],
+
+        "import/no-unused-modules": "off",
+        "import/no-anonymous-default-export": "off"
       }
     },
 
@@ -135,11 +138,29 @@
       }
     },
     {
-      "files": ["**/composables/*.ts", "**/composables/*.js"],
+      "files": ["**/composables/**/*.{js,ts}"],
 
       "rules": {
-        "unicorn/consistent-function-scoping": "off",
-        "import/no-unused-modules": "off"
+        "unicorn/consistent-function-scoping": "off"
+      }
+    },
+    {
+      "files": ["**/{composables,utils}/**/*.{js,ts}"],
+      "rules": {
+        "import/prefer-default-export": "off",
+        "func-names": "off"
+      }
+    },
+    {
+      "files": ["**/layouts/**/*.{js,ts}", "**/pages/**/*.{js,ts}"],
+      "rules": {
+        "vue/multi-word-component-names": "off"
+      }
+    },
+    {
+      "files": ["server/**/*.{js,ts}"],
+      "rules": {
+        "no-param-reassign": "off"
       }
     }
   ]

--- a/vue.json
+++ b/vue.json
@@ -102,7 +102,6 @@
             "message": "The comma operator is confusing and a common mistake. Don’t use it!"
           }
         ],
-        "vue/no-required-prop-with-default": ["error", { "autofix": true }],
 
         "import/no-unused-modules": "off",
         "import/no-anonymous-default-export": "off"

--- a/vue.json
+++ b/vue.json
@@ -102,6 +102,7 @@
             "message": "The comma operator is confusing and a common mistake. Don’t use it!"
           }
         ],
+        "vue/no-required-prop-with-default": ["error", { "autofix": true }],
 
         "import/no-unused-modules": "off",
         "import/no-anonymous-default-export": "off"

--- a/vue.json
+++ b/vue.json
@@ -139,7 +139,6 @@
     },
     {
       "files": ["**/composables/**/*.{js,ts}"],
-
       "rules": {
         "unicorn/consistent-function-scoping": "off"
       }

--- a/vue.json
+++ b/vue.json
@@ -144,13 +144,6 @@
       }
     },
     {
-      "files": ["**/{composables,utils}/**/*.{js,ts}"],
-      "rules": {
-        "import/prefer-default-export": "off",
-        "func-names": "off"
-      }
-    },
-    {
       "files": ["**/layouts/**/*.{js,ts}", "**/pages/**/*.{js,ts}"],
       "rules": {
         "vue/multi-word-component-names": "off"
@@ -159,7 +152,24 @@
     {
       "files": ["server/**/*.{js,ts}"],
       "rules": {
-        "no-param-reassign": "off"
+        "no-param-reassign": [
+          "error",
+          {
+            "props": true,
+            "ignorePropertyModificationsFor": [
+              "accumulator",
+              "ctx",
+              "context",
+              "req",
+              "request",
+              "res",
+              "response",
+              "$scope",
+              "staticContext",
+              "event"
+            ]
+          }
+        ]
       }
     }
   ]


### PR DESCRIPTION
Fixes #680.

### Changes made

#### import/no-unused-modules
Was only disabled in `composables`, now disabled globally when **Vue** config is enabled. 

Unfortunately, **Eslint** does not understand **Nuxt** and many **Vue** core principles. Therefore, it generates lots of false positives. I kept adding folders to the ignore list but I decided it would be better to disable this rule globally. It was too much hassle.

#### import/no-anonymous-default-export
Disabled globally when **Vue** config is enabled. 

The main reason for this, is that both **Vue** and **Nuxt** docs use *default anonymous exports* [pretty](https://nuxt.com/docs/guide/directory-structure/plugins) [much](https://vuejs.org/guide/components/props.html) [everywhere](https://nuxt.com/docs/guide/directory-structure/nuxt.config): for components (options API), composables, utilities, etc. I figured it would be better to honor the documentation here and to stop forcing the user to assign to a variable first. Since this is used pretty much all over projects, I disabled this rule globally.

#### import/prefer-default-export & func-names
Disabled for *composables* and *utils*.

For composables, [Vue](https://vuejs.org/guide/reusability/composables.html#mouse-tracker-example) prefers named exports, whereas [Nuxt](https://nuxt.com/docs/guide/directory-structure/composables#composables-directory) has no preference. Since there is no rule for forcing to use named exports, I opted to disable these two rules. This way it is up to the developer to choose a syntax and stick with it. The downside to this is more room for inconsistency. But the upside is that both the framework's preference can be honored. I disabled these rules for the *utils* folder as well, since they usually look a lot like composables. I was unable to find a specific preference in either framework's documentation for this.

#### vue/multi-word-component-names
Disabled for *layouts* and *pages*.

I believe layouts and pages differ from regular components and should be exempt from this rule. In **Nuxt**, for example, the filenames of these often, by convention, look like `default.vue` (layout) or `[slug].vue` (page). I could not really find a reference for **Vue**. Mainly because the prefered folder structure is not as solidly defined as it is for **Nuxt**.

#### no-param-reassign (Nuxt only)
Disabled for the *server* directory.

As can be seen [here](https://nuxt.com/docs/guide/directory-structure/server#server-middleware) it is common practice to assign to parameters in the *server* directory. I therefore disabled this rule there.

### Final words
These are just some things I encountered while linting/maintaining 2 small to medium sized projects. I can imagine there is more to be found. I am also very open to discussion about any changes made in this PR. If anyone has different ideas or opinions, please share!