### PR TITLE
Fix Nuxt 3 (non-TS) support

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Example `.eslintrc.json` for a **TypeScript React** project:
 }
 ```
 
-Example `.eslintrc.json` for a **Javascript Vue 3** project:
+Example `.eslintrc.json` for a **Vue 3** project:
 
 ```json
 {
@@ -107,7 +107,7 @@ Example `.eslintrc.json` for a **Javascript Vue 3** project:
 }
 ```
 
-Example `.eslintrc.json` for a **Javascript Nuxt 3** project:
+Example `.eslintrc.json` for a **Nuxt 3** project:
 
 ```json
 {

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Example `.eslintrc.json` for a **TypeScript React** project:
 }
 ```
 
-Example `.eslintrc.json` for a **Vue 3/Nuxt 3** project:
+Example `.eslintrc.json` for a **Javascript Vue 3** project:
 
 ```json
 {
@@ -100,6 +100,26 @@ Example `.eslintrc.json` for a **Vue 3/Nuxt 3** project:
     "import/resolver": {
       "alias": {
         "map": [["@", "./src/"]],
+        "extensions": [".js", ".vue"]
+      }
+    }
+  }
+}
+```
+
+Example `.eslintrc.json` for a **Javascript Nuxt 3** project:
+
+```json
+{
+  "extends": ["hardcore", "hardcore/vue"],
+
+  "settings": {
+    "import/resolver": {
+      "alias": {
+        "map": [
+          ["@", "./"], 
+          ["#imports", ".nuxt/imports.d.ts"]
+        ],
         "extensions": [".js", ".vue"]
       }
     }

--- a/vue.json
+++ b/vue.json
@@ -112,7 +112,12 @@
         "import/no-anonymous-default-export": "off"
       }
     },
-
+    {
+      "files": ["nuxt.config.js", "*.vue"],
+      "rules": {
+        "no-undef": "off"
+      }
+    },
     {
       "files": ["*.vue"],
 
@@ -158,7 +163,6 @@
           { "allowCallExpression": false, "allowObject": true }
         ],
 
-        "no-undef": "off",
         "init-declarations": "off",
         "@typescript-eslint/init-declarations": "off",
         "import/unambiguous": "off",

--- a/vue.json
+++ b/vue.json
@@ -113,7 +113,7 @@
       }
     },
     {
-      "files": ["nuxt.config.js", "*.vue"],
+      "files": ["nuxt.config.{js,ts}"],
       "rules": {
         "no-undef": "off"
       }
@@ -163,6 +163,7 @@
           { "allowCallExpression": false, "allowObject": true }
         ],
 
+        "no-undef": "off",
         "init-declarations": "off",
         "@typescript-eslint/init-declarations": "off",
         "import/unambiguous": "off",


### PR DESCRIPTION
Fixes #589.

Seperate config examples for Vue 3 (JS) and Nuxt 3 (JS).

- `@` points to `./src/` for `Vue`, and to `./` for `Nuxt`.
- Importing from `#imports` for Javascript Nuxt can be fixed by creating an alias in `.eslintrc.json`. This is now shown in the example.
- Disable `no-undef` for `nuxt.config.js` too, as `defineNuxtConfig` will raise this error.