### PR TITLE
Remove total-functions/no-unsafe-enum-assignment

### DIFF
--- a/ts.json
+++ b/ts.json
@@ -155,7 +155,6 @@
 
         "total-functions/no-unsafe-readonly-mutable-assignment": "error",
         "total-functions/require-strict-mode": "error",
-        "total-functions/no-unsafe-enum-assignment": "error",
         "total-functions/no-partial-url-constructor": "error",
         "total-functions/no-partial-division": "error",
         "total-functions/no-partial-string-normalize": "error",


### PR DESCRIPTION
The rule was "deprecated" ([removed](https://github.com/danielnixon/eslint-plugin-total-functions/commit/df26d9af63773ae0ba14ccffb47bb50b78790fe7)) from the package.

1. [x] Wait for https://github.com/cartant/eslint-plugin-etc/issues/53
2. [x] Update TypeScript to v5