### PR TITLE
Add tweaks from `nuxt/eslint-config`

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The most strict (yet practical) ESLint config.
 Aims to include as many plugins and rules as possible to make your code
 extremely consistent and robust.
 
-**46 plugins. 1228 rules.**
+**46 plugins. 1229 rules.**
 
 ## Usage
 
@@ -279,10 +279,10 @@ Config for Vue 3/Nuxt 3.
 
 | Plugin                                                                                             | Enabled rules |
 | -------------------------------------------------------------------------------------------------- | ------------: |
-| [eslint-plugin-vue](https://github.com/vuejs/eslint-plugin-vue)                                    |           155 |
+| [eslint-plugin-vue](https://github.com/vuejs/eslint-plugin-vue)                                    |           156 |
 | [eslint-plugin-vuejs-accessibility](https://github.com/vue-a11y/eslint-plugin-vuejs-accessibility) |            21 |
 | [eslint-plugin-vue-scoped-css](https://github.com/future-architect/eslint-plugin-vue-scoped-css)   |            13 |
-| **Total:**                                                                                         |       **189** |
+| **Total:**                                                                                         |       **190** |
 
 ### `hardcore/react-testing-library`
 

--- a/vue.json
+++ b/vue.json
@@ -177,9 +177,20 @@
       }
     },
     {
-      "files": ["**/layouts/**/*.{js,ts}", "**/pages/**/*.{js,ts}"],
+      "files": [
+        "**/pages/**/*.{js,ts,vue}",
+        "**/layouts/**/*.{js,ts,vue}",
+        "**/app.{js,ts,vue}",
+        "**/error.{js,ts,vue}"
+      ],
       "rules": {
         "vue/multi-word-component-names": "off"
+      }
+    },
+    {
+      "files": ["**/layouts/**/*.{js,ts}", "**/pages/**/*.{js,ts}"],
+      "rules": {
+        "vue/no-multiple-template-root": "error"
       }
     },
     {

--- a/vue.json
+++ b/vue.json
@@ -188,7 +188,7 @@
       }
     },
     {
-      "files": ["**/layouts/**/*.{js,ts}", "**/pages/**/*.{js,ts}"],
+      "files": ["**/layouts/**/*.{js,ts,vue}", "**/pages/**/*.{js,ts,vue}"],
       "rules": {
         "vue/no-multiple-template-root": "error"
       }


### PR DESCRIPTION
Applied some minor tweaks from https://github.com/nuxt/eslint-config/blob/main/packages/eslint-config/index.js.

I didn't need a seperate `Nuxt` config yet, as this should not interfere with `Vue`.

For now I chose not to disable the rules disabled in `nuxt/eslint-config` because I haven't personally encountered issues yet.