### PR TITLE
Do not recommend default exports

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The most strict (yet practical) ESLint config.
 Aims to include as many plugins and rules as possible to make your code
 extremely consistent and robust.
 
-**49 plugins. 1348 rules.**
+**49 plugins. 1347 rules.**
 
 ## Usage
 
@@ -206,7 +206,7 @@ Base framework-agnostic config.
 | [eslint-plugin-regexp](https://github.com/ota-meshi/eslint-plugin-regexp)                                 |            79 |
 | [eslint-plugin-putout](https://github.com/coderaiser/putout/tree/master/packages/eslint-plugin-putout)    |            73 |
 | [eslint-plugin-sonar](https://github.com/un-ts/eslint-plugin-sonar)                                       |            49 |
-| [eslint-plugin-import](https://github.com/benmosher/eslint-plugin-import)                                 |            34 |
+| [eslint-plugin-import](https://github.com/benmosher/eslint-plugin-import)                                 |            33 |
 | [eslint-plugin-sonarjs](https://github.com/SonarSource/eslint-plugin-sonarjs)                             |            31 |
 | [HTML ESLint](https://github.com/yeonjuan/html-eslint)                                                    |            21 |
 | [eslint-plugin-promise](https://github.com/xjamundx/eslint-plugin-promise)                                |            13 |
@@ -225,7 +225,7 @@ Base framework-agnostic config.
 | [eslint-plugin-no-only-tests](https://github.com/levibuzolic/eslint-plugin-no-only-tests)                 |             1 |
 | [eslint-plugin-json](https://github.com/azeemba/eslint-plugin-json)¹                                      |             1 |
 | [eslint-plugin-prettier](https://github.com/prettier/eslint-plugin-prettier)²                             |             1 |
-| **Total:**                                                                                                |       **628** |
+| **Total:**                                                                                                |       **627** |
 
 ¹ eslint-plugin-json actually includes 19 rules, but I consider them as one
 "no-invalid-json" rule.

--- a/base.json
+++ b/base.json
@@ -421,7 +421,6 @@
     "import/no-relative-packages": "error",
     "import/no-import-module-exports": "error",
     "import/no-empty-named-blocks": "error",
-    "import/no-default-export": "error",
 
     "import/no-unresolved": [
       "error",

--- a/base.json
+++ b/base.json
@@ -415,13 +415,13 @@
     "import/first": "error",
     "import/exports-last": "error",
     "import/no-namespace": "error",
-    "import/prefer-default-export": "error",
     "import/max-dependencies": "error",
     "import/no-named-default": "error",
     "import/no-commonjs": "error",
     "import/no-relative-packages": "error",
     "import/no-import-module-exports": "error",
     "import/no-empty-named-blocks": "error",
+    "import/no-default-export": "error",
 
     "import/no-unresolved": [
       "error",

--- a/disabled-rules.json
+++ b/disabled-rules.json
@@ -32,12 +32,12 @@
   "import/no-internal-modules": "off",
   "import/no-relative-parent-imports": "off",
   "import/no-nodejs-modules": "off",
-  "import/no-default-export": "off",
   "import/no-named-export": "off",
   "import/dynamic-import-chunkname": "off",
   "import/no-unassigned-import": "off",
   "import/group-exports": "off",
   "import/consistent-type-specifier-style": "off",
+  "import/prefer-default-export": "off",
 
   "unicorn/no-array-callback-reference": "off",
   "unicorn/no-keyword-prefix": "off",

--- a/disabled-rules.json
+++ b/disabled-rules.json
@@ -32,6 +32,7 @@
   "import/no-internal-modules": "off",
   "import/no-relative-parent-imports": "off",
   "import/no-nodejs-modules": "off",
+  "import/no-default-export": "off",
   "import/no-named-export": "off",
   "import/dynamic-import-chunkname": "off",
   "import/no-unassigned-import": "off",


### PR DESCRIPTION
`export default` should be banned completely, but unfortunately many frameworks rely on it.

Even though [`import/no-default-export`](https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/no-default-export.md) rule remains disabled, I recommend avoiding default exports, if possible.

Reasons:

1. If default exported name doesn't match file name
   1. autocomplete doesn't work
   2. confusion increases
2. If a module has both named exports and a default export
   1. confusion increases
3. You can export the same thing as a named export and as a default export
   1. if you want to increase clutter and confusion, sure why not?
4. If you used default export but then had to export another thing, you either have to use named exports together with a default export, or you have to change default export to a named export
   1. if you love refactoring...
5. If declaration and default export are separate
   1. good luck connecting the dots
6. Have to use `.default` in _some_ cases (like with dynamic `import()`)
7. You can accidentally use a different name in each import site
   1. I don't blame you

Ref #846 Ban default exports
