### PR TITLE
Migrate TypeScript ESLint rules to TypeScript ESLint v8

### DIFF
--- a/ts-for-js.json
+++ b/ts-for-js.json
@@ -17,9 +17,6 @@
     "@typescript-eslint/require-await": "error",
     "@typescript-eslint/return-await": ["error", "always"],
 
-    "no-throw-literal": "off",
-    "@typescript-eslint/no-throw-literal": "error",
-
     "prefer-promise-reject-errors": "off",
     "@typescript-eslint/prefer-promise-reject-errors": "error",
 
@@ -29,7 +26,6 @@
     "@typescript-eslint/await-thenable": "error",
     "@typescript-eslint/ban-ts-comment": "error",
     "@typescript-eslint/ban-tslint-comment": "error",
-    "@typescript-eslint/no-base-to-string": "error",
     "@typescript-eslint/no-dynamic-delete": "error",
     "@typescript-eslint/no-extraneous-class": "error",
     "@typescript-eslint/no-for-in-array": "error",
@@ -46,6 +42,8 @@
     "@typescript-eslint/unbound-method": "error",
     "@typescript-eslint/no-confusing-void-expression": "error",
     "@typescript-eslint/no-useless-empty-export": "error",
+
+    "@typescript-eslint/no-base-to-string": ["error", { "checkUnknown": true }],
 
     "@typescript-eslint/no-unnecessary-boolean-literal-compare": [
       "error",
@@ -200,7 +198,7 @@
     "etc/no-internal": "error",
 
     "import/no-deprecated": "off",
-    "etc/no-deprecated": "error",
+    "@typescript-eslint/no-deprecated": "error",
 
     "typescript-compat/compat": "error",
 

--- a/ts.json
+++ b/ts.json
@@ -98,6 +98,20 @@
           { "requireDefaultForNonUnion": true }
         ],
 
+        "@typescript-eslint/no-unnecessary-condition": [
+          "error",
+          { "checkTypePredicates": true }
+        ],
+
+        "@typescript-eslint/only-throw-error": [
+          "error",
+          {
+            "allowRethrowing": false,
+            "allowThrowingAny": false,
+            "allowThrowingUnknown": false
+          }
+        ],
+
         "prefer-destructuring": "off",
         "@typescript-eslint/prefer-destructuring": [
           "error",


### PR DESCRIPTION
Putout and/or some other dependencies prevent upgrading to TypeScript ESLint v8.
This PR is just for documenting what's new in TypeScript ESLint v8.
The actual upgrade will be in a separate PR.